### PR TITLE
Calculate service levels based on best-serviced stop

### DIFF
--- a/datagen/gtfs/models.py
+++ b/datagen/gtfs/models.py
@@ -56,6 +56,7 @@ class Trip(object):
     shape: List[Tuple[float, float]]
     direction_id: int
     service: Service
+    stops: set[str]
 
     def __post_init__(self):
         self.stop_times = []

--- a/datagen/gtfs/models.py
+++ b/datagen/gtfs/models.py
@@ -56,13 +56,17 @@ class Trip(object):
     shape: List[Tuple[float, float]]
     direction_id: int
     service: Service
-    stops: set[str]
 
     def __post_init__(self):
         self.stop_times = []
 
     def add_stop_time(self, stop_time):
         self.stop_times.append(stop_time)
+
+    @functools.cached_property
+    def stop_ids(self):
+        assert len(self.stop_times) > 0, "Stop ids inaccessible; stop times not yet populated"
+        return set([stop_time.stop.id for stop_time in self.stop_times])
 
 
 @dataclass

--- a/datagen/gtfs/network.py
+++ b/datagen/gtfs/network.py
@@ -133,6 +133,7 @@ def link_trips(trip_dicts, services_by_id, shapes_by_id):
                 direction_id=int(trip_dict["direction_id"]),
                 shape_id=trip_dict["shape_id"],
                 shape=shapes_by_id[trip_dict["shape_id"]],
+                stops=set(),
             )
             res[trip_id] = trip
     return res
@@ -150,6 +151,7 @@ def link_stop_times(stop, stop_time_dicts_for_stop_id, trips_by_id):
                 trip=trip,
                 time=time_from_string(stop_time_dict["departure_time"]),
             )
+            trip.stops.add(stop.id)
             added += 1
             stop_times.append(stop_time)
             trip.add_stop_time(stop_time)

--- a/datagen/gtfs/network.py
+++ b/datagen/gtfs/network.py
@@ -133,7 +133,6 @@ def link_trips(trip_dicts, services_by_id, shapes_by_id):
                 direction_id=int(trip_dict["direction_id"]),
                 shape_id=trip_dict["shape_id"],
                 shape=shapes_by_id[trip_dict["shape_id"]],
-                stops=set(),
             )
             res[trip_id] = trip
     return res

--- a/datagen/gtfs/network.py
+++ b/datagen/gtfs/network.py
@@ -150,7 +150,6 @@ def link_stop_times(stop, stop_time_dicts_for_stop_id, trips_by_id):
                 trip=trip,
                 time=time_from_string(stop_time_dict["departure_time"]),
             )
-            trip.stops.add(stop.id)
             added += 1
             stop_times.append(stop_time)
             trip.add_stop_time(stop_time)

--- a/datagen/gtfs/service_levels.py
+++ b/datagen/gtfs/service_levels.py
@@ -1,6 +1,7 @@
 from collections import Counter
 from datetime import date, timedelta
 from typing import List, Dict
+from .util import flatten
 
 from gtfs.models import Service, ServiceExceptionType
 from gtfs.trips import TripSummary
@@ -49,8 +50,8 @@ def filter_trips_serving_most_common_stop(trips: List[TripSummary]):
 
     for trips in trips_by_route_id.values():
         # What the route id actually is doesn't matter, as long as it's bucketed
-        count = Counter([list(trip.stop_ids) for trip in trips])
-        [(most_serviced_stop, )] = count.most_common(1)
+        count = Counter(flatten([trip.stop_ids for trip in trips]))
+        [(most_serviced_stop, _)] = count.most_common(1)
         accepted.extend(
             filter(lambda trip: most_serviced_stop in trip.stop_ids, trips)
         )

--- a/datagen/gtfs/service_levels.py
+++ b/datagen/gtfs/service_levels.py
@@ -1,5 +1,6 @@
-from typing import List, Dict
+from collections import Counter
 from datetime import date, timedelta
+from typing import List, Dict
 
 from gtfs.models import Service, ServiceExceptionType
 from gtfs.trips import TripSummary
@@ -41,6 +42,20 @@ def bucket_trips_by_hour(trips: List[TripSummary]):
         by_time_of_day[hour] += 0.5
     return by_time_of_day
 
+# Given a list of trips on a single date, prune to match a more realistic service level
+def prune_trips_single_date(trips: List[TripSummary]):
+    accepted: List[TripSummary] = []
+    trips_by_route_id = bucket_by(trips, "route_id")
+
+    for trips in trips_by_route_id.values():
+        # What the route id actually is doesn't matter, as long as it's bucketed
+        count = Counter([list(trip.stops) for trip in trips])
+        [(most_serviced_stop, )] = count.most_common(1)
+        accepted.extend(
+            filter(lambda trip: most_serviced_stop in trip.stops, trips)
+        )
+
+    return accepted
 
 def summarize_trips_by_date(line_id: str, trips: List[TripSummary]):
     summary_by_date = {}
@@ -55,7 +70,8 @@ def summarize_trips_by_date(line_id: str, trips: List[TripSummary]):
         trips_for_date = [
             t for t in trips if t.service in services_for_date and t.route_id in valid_route_ids
         ]
-        summary_by_date[date] = bucket_trips_by_hour(trips_for_date)
+        pruned_trips = prune_trips_single_date(trips_for_date)
+        summary_by_date[date] = bucket_trips_by_hour(pruned_trips)
         date += timedelta(days=1)
 
     reduced_summary = []

--- a/datagen/gtfs/service_levels.py
+++ b/datagen/gtfs/service_levels.py
@@ -43,16 +43,16 @@ def bucket_trips_by_hour(trips: List[TripSummary]):
     return by_time_of_day
 
 # Given a list of trips on a single date, prune to match a more realistic service level
-def prune_trips_single_date(trips: List[TripSummary]):
+def filter_trips_serving_most_common_stop(trips: List[TripSummary]):
     accepted: List[TripSummary] = []
     trips_by_route_id = bucket_by(trips, "route_id")
 
     for trips in trips_by_route_id.values():
         # What the route id actually is doesn't matter, as long as it's bucketed
-        count = Counter([list(trip.stops) for trip in trips])
+        count = Counter([list(trip.stop_ids) for trip in trips])
         [(most_serviced_stop, )] = count.most_common(1)
         accepted.extend(
-            filter(lambda trip: most_serviced_stop in trip.stops, trips)
+            filter(lambda trip: most_serviced_stop in trip.stop_ids, trips)
         )
 
     return accepted
@@ -70,7 +70,7 @@ def summarize_trips_by_date(line_id: str, trips: List[TripSummary]):
         trips_for_date = [
             t for t in trips if t.service in services_for_date and t.route_id in valid_route_ids
         ]
-        pruned_trips = prune_trips_single_date(trips_for_date)
+        pruned_trips = filter_trips_serving_most_common_stop(trips_for_date)
         summary_by_date[date] = bucket_trips_by_hour(pruned_trips)
         date += timedelta(days=1)
 

--- a/datagen/gtfs/trips.py
+++ b/datagen/gtfs/trips.py
@@ -12,6 +12,7 @@ class TripSummary:
     service: Service
     line: Line
     departure_time: datetime.timedelta
+    stops: set
 
 
 def get_trip_summaries_for_network(network: Network):
@@ -24,6 +25,7 @@ def get_trip_summaries_for_network(network: Network):
             service=trip.service,
             line=network.routes_by_id[trip.route_id].line,
             departure_time=trip.stop_times[0].time,
+            stops=trip.stops,
         )
         summaries.append(summary)
     return summaries

--- a/datagen/gtfs/trips.py
+++ b/datagen/gtfs/trips.py
@@ -12,7 +12,7 @@ class TripSummary:
     service: Service
     line: Line
     departure_time: datetime.timedelta
-    stops: set
+    stop_ids: set[str]
 
 
 def get_trip_summaries_for_network(network: Network):
@@ -25,7 +25,7 @@ def get_trip_summaries_for_network(network: Network):
             service=trip.service,
             line=network.routes_by_id[trip.route_id].line,
             departure_time=trip.stop_times[0].time,
-            stops=trip.stops,
+            stop_ids=trip.stop_ids,
         )
         summaries.append(summary)
     return summaries

--- a/datagen/gtfs/trips.py
+++ b/datagen/gtfs/trips.py
@@ -14,6 +14,9 @@ class TripSummary:
     departure_time: datetime.timedelta
     stop_ids: set[str]
 
+    def __getitem__(self, item):
+        return getattr(self, item)
+
 
 def get_trip_summaries_for_network(network: Network):
     summaries = []

--- a/datagen/gtfs/util.py
+++ b/datagen/gtfs/util.py
@@ -19,6 +19,8 @@ def bucket_by(items, key_getter):
         key_items.append(item)
     return res
 
+def flatten(list_of_lists):
+    return [item for sublist in list_of_lists for item in sublist]
 
 def get_ranges_of_same_value(items_dict):
     current_value = None


### PR DESCRIPTION
This took me too long lol

Per @friendchris, during bustitution lines are split up into segments that cause a service level to appear erroneously high.

This adjusts service level calculation to filter on trips that service the most frequented stop only. No idea if it's right, though. Might actually throw some unit tests at it, but @idreyn I'm curious what you think before I get to that.